### PR TITLE
pypdfium2 4.19.0 (move to main win only)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - sfe1ed40
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,15 +2,16 @@
 {% set version = "4.19.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1ca3a2ed080c263229af3fbff35ad7f751361861f10893d9908d4d852fe6eb28
 
 build:
-  skip: True  # [linux and (ppc64le or s390x)]
+  # Need rebuild only on windows
+  skip: true  # [unix]
   entry_points:
     - pypdfium2 = pypdfium2.__main__:cli_main
   script_env:
@@ -18,14 +19,14 @@ build:
   script:
     - cp bindings/raw.py src/pypdfium2/raw.py
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:
+    - pip
     - python
     - setuptools
-    - pip
-    - wheel !=0.38.0,!=0.38.1
+    - wheel
     - pdfium-binaries 118.0.5975
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   script_env:
     - PDFIUM_PLATFORM=none
   script:
-    - cp bindings/raw.py src/pypdfium2/raw.py
+    - python -c "import shutil; shutil.copy('bindings/raw.py', 'src/pypdfium2/raw.py')"
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 2
 


### PR DESCRIPTION
pypdfium2 4.19.0 

**Destination channel:** Defaults

### Links

- [PKG-16967]
- dev_url:        https://github.com/pypdfium2-team/pypdfium2/tree/4.19.0

### Explanation of changes:

- new version number


[PKG-16967]: https://anaconda.atlassian.net/browse/PKG-16967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ