### PR TITLE
enable win-64 via sourcebuild-toolchained backend

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,21 +3,32 @@ REM ===========================================================================
 REM win-64 pdfium source build via pypdfium2 sourcebuild-toolchained backend
 REM (depot_tools + gclient sync + Google prebuilt clang + local MSVC/Windows SDK).
 REM
-REM AMI PREREQUISITES (not conda-expressible; must exist on the win-64 worker):
-REM   1. MinGit (Git-for-Windows) at C:\Git -- depot_tools bootstrap rejects conda
-REM      git; it requires an ancestor dir named "Git" with cmd\git.exe.
-REM   2. Windows SDK 10.0.26100 "Debugging Tools for Windows" feature -- pdfium's
-REM      vs_toolchain.py copies Debuggers\x64\dbghelp.dll during gn gen.
+REM AMI PREREQUISITE (not conda-expressible; must exist on the win-64 worker):
+REM   Windows SDK 10.0.26100 "Debugging Tools for Windows" feature -- pdfium's
+REM   vs_toolchain.py copies Debuggers\x64\dbghelp.dll during gn gen.
+REM MinGit is self-provisioned below (depot_tools rejects conda git, which lacks
+REM the Git-for-Windows layout its bootstrap looks for).
 REM ===========================================================================
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
-REM depot_tools needs a Git-for-Windows-layout git ahead of conda git on PATH
+
+REM depot_tools bootstrap needs a Git-for-Windows-layout git (an ancestor dir named
+REM "Git" with cmd\git.exe); conda git does not qualify. Provision MinGit at C:\Git
+REM if the worker doesn't already have one.
+if not exist C:\Git\cmd\git.exe (
+  echo Provisioning MinGit at C:\Git ...
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/MinGit-2.55.0.3-64-bit.zip' -OutFile \"$env:TEMP\MinGit.zip\"; Expand-Archive -Path \"$env:TEMP\MinGit.zip\" -DestinationPath C:\Git -Force"
+  if errorlevel 1 exit 1
+)
 set PATH=C:\Git\cmd;%PATH%
+
 REM ctypesgen auto-selects cl.exe under vs2022 (its -E output is unparseable);
 REM force clang. An explicit CPP is used verbatim, so it must include the -E flag.
 set CPP=clang -E
+
 REM 1) build pdfium from source (writes data\sourcebuild\{pdfium.dll,bindings.py})
 "%PYTHON%" setupsrc\build_toolchained.py
 if errorlevel 1 exit 1
+
 REM 2) wrap the built pdfium into the package; ctypesgen (host) regenerates bindings
 set PDFIUM_PLATFORM=sourcebuild
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,18 +2,13 @@
 REM ===========================================================================
 REM win-64 pdfium source build via pypdfium2 sourcebuild-toolchained backend
 REM (depot_tools + gclient sync + Google prebuilt clang + local MSVC/Windows SDK).
-REM
-REM AMI PREREQUISITE (not conda-expressible; must exist on the win-64 worker):
-REM   Windows SDK 10.0.26100 "Debugging Tools for Windows" feature -- pdfium's
-REM   vs_toolchain.py copies Debuggers\x64\dbghelp.dll during gn gen.
-REM MinGit is self-provisioned below (depot_tools rejects conda git, which lacks
-REM the Git-for-Windows layout its bootstrap looks for).
+REM No worker-AMI changes required: MinGit is self-provisioned, and pdfium's
+REM debugger-DLL copy (which would otherwise need the SDK "Debugging Tools"
+REM feature) is patched out -- dbghelp is not needed for the shipped release lib.
 REM ===========================================================================
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 
-REM depot_tools bootstrap needs a Git-for-Windows-layout git (an ancestor dir named
-REM "Git" with cmd\git.exe); conda git does not qualify. Provision MinGit at C:\Git
-REM if the worker doesn't already have one.
+REM depot_tools bootstrap needs a Git-for-Windows-layout git; provision MinGit.
 if not exist C:\Git\cmd\git.exe (
   echo Provisioning MinGit at C:\Git ...
   powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/MinGit-2.55.0.3-64-bit.zip' -OutFile \"$env:TEMP\MinGit.zip\"; Expand-Archive -Path \"$env:TEMP\MinGit.zip\" -DestinationPath C:\Git -Force"
@@ -21,15 +16,36 @@ if not exist C:\Git\cmd\git.exe (
 )
 set PATH=C:\Git\cmd;%PATH%
 
-REM ctypesgen auto-selects cl.exe under vs2022 (its -E output is unparseable);
-REM force clang. An explicit CPP is used verbatim, so it must include the -E flag.
+REM ctypesgen auto-selects cl.exe under vs2022 (unparseable -E); force clang -E.
 set CPP=clang -E
 
-REM 1) build pdfium from source (writes data\sourcebuild\{pdfium.dll,bindings.py})
+REM Pass 1: sync the pdfium checkout (+ first gn gen). gclient's gsutil DEPS hooks
+REM can flake transiently (lockfile error), leaving the checkout without gn; each
+REM re-run resumes the sync, so retry until gn is present. Once the checkout has
+REM gn, sync is complete and gn gen will have failed only on the dbghelp step,
+REM which the patch below removes.
+set _tries=0
+:sync_loop
+"%PYTHON%" setupsrc\build_toolchained.py
+if exist sbuild\toolchained\pdfium\buildtools\win\gn.exe goto synced
+set /a _tries+=1
+if %_tries% GEQ 4 (echo ERROR: gclient sync did not complete after %_tries% attempts & exit 1)
+echo pdfium sync incomplete ^(attempt %_tries%^), retrying...
+goto sync_loop
+:synced
+
+REM Patch out the _CopyDebugger CALL (keeps CopyDlls' release-CRT copy intact).
+REM dbghelp is only a crash-symbolization aid for pdfium's own tests; the shipped
+REM package contains only pdfium.dll, so this removes the SDK-feature dependency.
+"%PYTHON%" -c "import pathlib,re; p=pathlib.Path(r'sbuild/toolchained/pdfium/build/vs_toolchain.py'); s=p.read_text(); n,c=re.subn(r'(?<!def )_CopyDebugger\(target_dir, target_cpu\)','pass  # _CopyDebugger disabled (dbghelp not needed for shipped release lib)',s); assert c>=1,'patch site not found'; p.write_text(n); print('patched _CopyDebugger call(s):',c)"
+if errorlevel 1 exit 1
+
+REM Pass 2: reuse the synced checkout (skips gclient), re-run gn gen (now clean)
+REM + ninja build, then pack data\sourcebuild\.
 "%PYTHON%" setupsrc\build_toolchained.py
 if errorlevel 1 exit 1
 
-REM 2) wrap the built pdfium into the package; ctypesgen (host) regenerates bindings
+REM Wrap the built pdfium into the package; ctypesgen (host) regenerates bindings.
 set PDFIUM_PLATFORM=sourcebuild
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,12 +11,16 @@ set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 REM depot_tools' bootstrap only accepts a Git-for-Windows-layout git: an ancestor
 REM dir named "Git" with cmd\git.exe, or an MSYS2 ucrt64/clang64/clangarm64 tree.
 REM Neither conda `git` (Library\bin\git.exe) nor `msys2-git` (Library\usr\bin)
-REM matches, so provision MinGit (the GfW portable layout) if absent.
-if not exist C:\Git\cmd\git.exe (
-  echo Provisioning MinGit at C:\Git ...
-  powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/MinGit-2.55.0.3-64-bit.zip' -OutFile \"$env:TEMP\MinGit.zip\"; Expand-Archive -Path \"$env:TEMP\MinGit.zip\" -DestinationPath C:\Git -Force"
-  if errorlevel 1 exit 1
-)
+REM matches, so provision MinGit (the GfW portable layout) if absent. The download
+REM is SHA-256 pinned (git-for-windows' published checksum for this exact asset) and
+REM verified before extraction, so a tampered/MITM'd zip fails the build.
+REM (goto-label rather than an if(...) block: the PowerShell below contains parens
+REM inside its quoted -Command, which cmd's parenthesized-block parser mishandles.)
+if exist C:\Git\cmd\git.exe goto mingit_ready
+echo Provisioning MinGit at C:\Git ...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; $zip=\"$env:TEMP\MinGit.zip\"; $sha='f48e2d2dc74a24454adc6d8fd0ac25bf9c2386f19cfb06202b9465aaad4f9f05'; Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/MinGit-2.55.0.3-64-bit.zip' -OutFile $zip; $h=(Get-FileHash -Algorithm SHA256 $zip).Hash.ToLower(); if ($h -ne $sha) { throw \"MinGit SHA-256 mismatch: got $h expected $sha\" }; Expand-Archive -Path $zip -DestinationPath C:\Git -Force"
+if errorlevel 1 exit 1
+:mingit_ready
 set PATH=C:\Git\cmd;%PATH%
 REM allow `git apply` on the gclient-synced pdfium checkout regardless of owner
 git config --global --add safe.directory "*"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 @echo off
 REM ===========================================================================
-REM win-64 pdfium source build via pypdfium2 sourcebuild-toolchained backend
+REM win-64 pdfium source build via pypdfium2's sourcebuild-toolchained backend
 REM (depot_tools + gclient sync + Google prebuilt clang + local MSVC/Windows SDK).
 REM No worker-AMI changes required: MinGit is self-provisioned, and pdfium's
 REM debugger-DLL copy (which would otherwise need the SDK "Debugging Tools"
@@ -8,44 +8,56 @@ REM feature) is patched out -- dbghelp is not needed for the shipped release lib
 REM ===========================================================================
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 
-REM depot_tools bootstrap needs a Git-for-Windows-layout git; provision MinGit.
+REM depot_tools' bootstrap only accepts a Git-for-Windows-layout git: an ancestor
+REM dir named "Git" with cmd\git.exe, or an MSYS2 ucrt64/clang64/clangarm64 tree.
+REM Neither conda `git` (Library\bin\git.exe) nor `msys2-git` (Library\usr\bin)
+REM matches, so provision MinGit (the GfW portable layout) if absent.
 if not exist C:\Git\cmd\git.exe (
   echo Provisioning MinGit at C:\Git ...
   powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/MinGit-2.55.0.3-64-bit.zip' -OutFile \"$env:TEMP\MinGit.zip\"; Expand-Archive -Path \"$env:TEMP\MinGit.zip\" -DestinationPath C:\Git -Force"
   if errorlevel 1 exit 1
 )
 set PATH=C:\Git\cmd;%PATH%
+REM allow `git apply` on the gclient-synced pdfium checkout regardless of owner
+git config --global --add safe.directory "*"
 
 REM ctypesgen auto-selects cl.exe under vs2022 (unparseable -E); force clang -E.
 set CPP=clang -E
 
-REM Pass 1: sync the pdfium checkout (+ first gn gen). gclient's gsutil DEPS hooks
-REM can flake transiently (lockfile error), leaving the checkout without gn; each
-REM re-run resumes the sync, so retry until gn is present. Once the checkout has
-REM gn, sync is complete and gn gen will have failed only on the dbghelp step,
-REM which the patch below removes.
+REM Pass 1: sync the pdfium checkout (then gn gen, which fails on the debugger-DLL
+REM copy -- patched out below). depot_tools' gsutil bootstrap occasionally fails to
+REM lock its shared cache under gclient's parallel DEPS fetches (a known transient,
+REM not a recipe issue); a re-run resumes the checkout. Retry only until pdfium's gn
+REM binary is present (i.e. the sync completed) -- real build failures surface later
+REM at gn gen / ninja and are NOT retried here.
 set _tries=0
 :sync_loop
 "%PYTHON%" setupsrc\build_toolchained.py
 if exist sbuild\toolchained\pdfium\buildtools\win\gn.exe goto synced
 set /a _tries+=1
-if %_tries% GEQ 4 (echo ERROR: gclient sync did not complete after %_tries% attempts & exit 1)
+if %_tries% GEQ 4 (echo ERROR: pdfium sync did not complete after %_tries% attempts & exit 1)
 echo pdfium sync incomplete ^(attempt %_tries%^), retrying...
 goto sync_loop
 :synced
 
-REM Patch out the _CopyDebugger CALL (keeps CopyDlls' release-CRT copy intact).
-REM dbghelp is only a crash-symbolization aid for pdfium's own tests; the shipped
-REM package contains only pdfium.dll, so this removes the SDK-feature dependency.
-"%PYTHON%" -c "import pathlib,re; p=pathlib.Path(r'sbuild/toolchained/pdfium/build/vs_toolchain.py'); s=p.read_text(); n,c=re.subn(r'(?<!def )_CopyDebugger\(target_dir, target_cpu\)','pass  # _CopyDebugger disabled (dbghelp not needed for shipped release lib)',s); assert c>=1,'patch site not found'; p.write_text(n); print('patched _CopyDebugger call(s):',c)"
-if errorlevel 1 exit 1
+REM Skip pdfium's debugger-DLL copy. vs_toolchain.py copies dbghelp/dbgcore/etc.
+REM from the SDK "Debugging Tools" feature purely as a crash-symbolization aid for
+REM pdfium's own tests; the shipped conda package is just pdfium.dll, so removing
+REM the copy drops that AMI-only dependency. Applied as a reviewable patch.
+pushd sbuild\toolchained\pdfium
+git apply --ignore-whitespace "%RECIPE_DIR%\patches\skip-debugger-dll-copy.patch"
+if errorlevel 1 (popd & echo ERROR: skip-debugger-dll-copy.patch failed to apply & exit 1)
+popd
 
-REM Pass 2: reuse the synced checkout (skips gclient), re-run gn gen (now clean)
-REM + ninja build, then pack data\sourcebuild\.
+REM Pass 2: reuse the synced checkout; `gn gen` (generate the ninja build files from
+REM pdfium's GN config) now succeeds, then ninja builds pdfium and packs data\sourcebuild\.
 "%PYTHON%" setupsrc\build_toolchained.py
 if errorlevel 1 exit 1
 
-REM Wrap the built pdfium into the package; ctypesgen (host) regenerates bindings.
+REM Wrap the built pdfium into the package. PDFIUM_PLATFORM=sourcebuild tells
+REM pypdfium2 to consume the pdfium we just built (data\sourcebuild\pdfium.dll);
+REM "toolchained" refers to HOW that pdfium was built (build_toolchained.py above),
+REM matching upstream's own sbuild_one.yaml. ctypesgen (host) regenerates bindings.
 set PDFIUM_PLATFORM=sourcebuild
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,24 @@
+@echo off
+REM ===========================================================================
+REM win-64 pdfium source build via pypdfium2 sourcebuild-toolchained backend
+REM (depot_tools + gclient sync + Google prebuilt clang + local MSVC/Windows SDK).
+REM
+REM AMI PREREQUISITES (not conda-expressible; must exist on the win-64 worker):
+REM   1. MinGit (Git-for-Windows) at C:\Git -- depot_tools bootstrap rejects conda
+REM      git; it requires an ancestor dir named "Git" with cmd\git.exe.
+REM   2. Windows SDK 10.0.26100 "Debugging Tools for Windows" feature -- pdfium's
+REM      vs_toolchain.py copies Debuggers\x64\dbghelp.dll during gn gen.
+REM ===========================================================================
+set DEPOT_TOOLS_WIN_TOOLCHAIN=0
+REM depot_tools needs a Git-for-Windows-layout git ahead of conda git on PATH
+set PATH=C:\Git\cmd;%PATH%
+REM ctypesgen auto-selects cl.exe under vs2022 (its -E output is unparseable);
+REM force clang. An explicit CPP is used verbatim, so it must include the -E flag.
+set CPP=clang -E
+REM 1) build pdfium from source (writes data\sourcebuild\{pdfium.dll,bindings.py})
+"%PYTHON%" setupsrc\build_toolchained.py
+if errorlevel 1 exit 1
+REM 2) wrap the built pdfium into the package; ctypesgen (host) regenerates bindings
+set PDFIUM_PLATFORM=sourcebuild
+"%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,10 @@ about:
   description: |
     pypdfium2 is an ABI-level Python 3 binding to PDFium, a powerful and liberal-licensed library for PDF rendering,
     inspection, manipulation and creation.
-  license: Apache-2.0
+  # Upstream SPDX (pyproject.toml): "Apache-2.0 OR BSD-3-Clause". pdfium itself is
+  # BSD-3-Clause and is compiled/shipped in the built pdfium binary; CC-BY-4.0
+  # covers bundled docs/assets. License texts for all three are shipped below.
+  license: Apache-2.0 OR BSD-3-Clause
   license_family: Apache
   license_file:
     - LICENSES/Apache-2.0.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,6 @@ source:
   sha256: d0e0648fb2e28f50efcd1ec0a5a18ced9f4d66b2c227fae9b603f0a883b2d13f
 
 build:
-  # win-64 needs the sourcebuild-toolchained backend (depot_tools + MSVC); that
-  # integration is deferred to a follow-up ticket.
-  skip: True  # [win]
   entry_points:
     - pypdfium2 = pypdfium2_cli.__main__:cli_main
   number: 0
@@ -26,6 +23,10 @@ requirements:
     - ninja-base  # [not win]
     - llvm-tools  # [osx]     provides llvm-ar (pdfium's `ar -D` needs it; Apple ar lacks -D)
     - lld         # [osx]     provides ld64.lld (pdfium's clang-mode link uses lld)
+    # win toolchained bindings step: ctypesgen needs a gcc/clang preprocessor, but the
+    # win toolchain is MSVC-only. bld.bat forces `CPP=clang -E` (cl.exe's -E output is
+    # unparseable by ctypesgen).
+    - clang       # [win]
     - git
     - python
   host:
@@ -43,11 +44,13 @@ requirements:
     # tracked as real dependencies (CBC pins the versions). Only libs pdfium
     # actually links are listed -- libpng/libtiff are XFA-only codecs and XFA is
     # off, so they're deliberately left vendored/unlinked (verified: not in DT_NEEDED).
-    - zlib {{ zlib }}
-    - lcms2 {{ lcms2 }}
-    - openjpeg {{ openjpeg }}
-    - freetype {{ freetype }}
-    - libjpeg-turbo {{ libjpeg_turbo }}
+    # Native (linux/osx) backend only -- the win toolchained backend uses pdfium's
+    # hermetic vendored build, so these are not unvendored/tracked on win.
+    - zlib {{ zlib }}                     # [not win]
+    - lcms2 {{ lcms2 }}                   # [not win]
+    - openjpeg {{ openjpeg }}             # [not win]
+    - freetype {{ freetype }}             # [not win]
+    - libjpeg-turbo {{ libjpeg_turbo }}   # [not win]
   run:
     - python
 

--- a/recipe/patches/skip-debugger-dll-copy.patch
+++ b/recipe/patches/skip-debugger-dll-copy.patch
@@ -1,0 +1,22 @@
+--- a/build/vs_toolchain.py
++++ b/build/vs_toolchain.py
+@@ -430,7 +430,8 @@
+   _CopyRuntime(target_dir, runtime_dir, target_cpu, debug=False)
+   if configuration == 'Debug':
+     _CopyRuntime(target_dir, runtime_dir, target_cpu, debug=True)
+-  _CopyDebugger(target_dir, target_cpu)
++  pass  # pypdfium2-conda: skip debugger-DLL copy (dbghelp is a test-only
++          # crash-symbolization aid; the shipped package is just pdfium.dll)
+   if target_cpu == 'arm64':
+     target_dir = os.path.join(target_dir, 'win_clang_x64')
+     target_cpu = 'x64'
+@@ -439,7 +440,8 @@
+     _CopyRuntime(target_dir, runtime_dir, target_cpu, debug=False)
+     if configuration == 'Debug':
+       _CopyRuntime(target_dir, runtime_dir, target_cpu, debug=True)
+-    _CopyDebugger(target_dir, target_cpu)
++    pass  # pypdfium2-conda: skip debugger-DLL copy (dbghelp is a test-only
++          # crash-symbolization aid; the shipped package is just pdfium.dll)
+ 
+ 
+ def _CopyDebugger(target_dir, target_cpu):


### PR DESCRIPTION
pypdfium2 - enable win-64 via sourcebuild-toolchained backend

**Destination channel:** defaults

### Links

- [PKG-15083](https://anaconda.atlassian.net/browse/PKG-15083)
- [PKG-14868](https://anaconda.atlassian.net/browse/PKG-14868)
- [Upstream repository](https://github.com/pypdfium2-team/pypdfium2)
- [Upstream source-build CI (reference for the win toolchained path)](https://github.com/pypdfium2-team/pypdfium2/blob/main/.github/workflows/sbuild_one.yaml)


### Explanation of changes:

- **Enable win-64** (was `skip: True  # [win]`). The `sourcebuild-native` backend used on linux/osx is Linux-family only; Windows uses pypdfium2's `sourcebuild-toolchained` backend 


[PKG-15083]: https://anaconda.atlassian.net/browse/PKG-15083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14868]: https://anaconda.atlassian.net/browse/PKG-14868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ